### PR TITLE
Remove the aws-credentials linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,6 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: destroyed-symlinks
-      - id: detect-aws-credentials
       - id: detect-private-key
       - id: double-quote-string-fixer
       - id: end-of-file-fixer


### PR DESCRIPTION
This test is failing on pre-commit-ci as I don't have AWS credentials to
use and we don't use aws for this program so remove the test.