### PR TITLE
Update project from template.

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "checkout": null,
-  "commit": "fc50d158795ac714eef847187d34770a5660c2fe",
+  "commit": "4ffd96f5764b5ff8d5bae4b6a0c072ef6f028e57",
   "context": {
     "cookiecutter": {
       "_template": "git@github.com:abadger/cookiecutter-python-projects",

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,11 +141,6 @@ repos:
     hooks:
       - id: reorder-python-imports
         args: [--py37-plus]
-  - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.2.1
-    hooks:
-      - id: add-trailing-comma
-        args: [--py36-plus]
   - repo: local
     hooks:
       - id: git-diff


### PR DESCRIPTION
This removes the pre-commit trailing comma fixer.  The reason is that it
and yapf keep trying to make different changes to the same lines,
leading to pre-commit failures