### PR TITLE
Implement a SudokuCell class

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -23,8 +23,6 @@ jobs:
         platform:
           - {name: Linux, distro: ubuntu-latest, pip_cache_path: ~/.cache/pip}
         python:
-          - {version: 3.7, tox: py37}
-          - {version: 3.8, tox: py38}
           - {version: 3.9, tox: py39}
           - {version: "3.10", tox: py310}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,6 @@
 ---
+default_language_version:
+  python: python3.9
 repos:
   - repo: https://github.com/pre-commit/mirrors-yapf
     rev: v0.32.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 
 description = "A sudoku solver"
 home-page = "https://github.com/abadger/suds"
-requires-python = "~=3.0"
+requires-python = ">=3.9"
 readme = "README.md"
 dependencies = [
     "pydantic",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ documentation = "https://readthedocs.io/suds"
 # mesonpep517 from a checkout because 0.2.0 does not understand dependencies
 # Use my own fork of mesonpep517 because mesonpep517 uses meson to build so it
 # needs to have ninja added to its deps.
-requires = ["mesonpep517 @ git+https://gitlab.com/a.badger/mesonpep517@deps-fix", "meson[ninja]!==0.62.0.*"]
+requires = ["mesonpep517 @ git+https://gitlab.com/a.badger/mesonpep517@abadger-fork", "meson[ninja]!==0.62.0.*"]
 build-backend = "mesonpep517.buildapi"
 
 [tool.mesonpep517.metadata]

--- a/pytype.cfg
+++ b/pytype.cfg
@@ -26,7 +26,7 @@ pythonpath =
     .
 
 # Python version (major.minor) of the target code.
-python_version = 3.7
+python_version = 3.9
 
 # Check attribute values against their annotations. This flag is temporary and
 # will be removed once this behavior is enabled by default.

--- a/suds/board.py
+++ b/suds/board.py
@@ -47,13 +47,6 @@ class SudokuCell:
         return str(self.value) if self.value else repr(set(self._potential_values))
 
     @property
-    def solved(self) -> bool:
-        """If all but one value have been eliminated, then this is True."""
-        if len(self.potential_values) != 1:
-            return False
-        return True
-
-    @property
     def value(self) -> t.Union[int, None]:
         """Value of the cell or None if there is more than one possible value."""
         if len(self._potential_values) == 1:

--- a/suds/board.py
+++ b/suds/board.py
@@ -112,17 +112,17 @@ class SudokuBoard:
     def __init__(self, old_board: 'SudokuBoard' = None):
         """Create a Sudoku Board."""
         # FIXME: Seems like some of these should be computed from others
-        self.num_rows = 9
-        self.num_columns = 9
-        self.num_boxes = 9
+        self.num_rows: int = 9
+        self.num_columns: int = 9
+        self.num_boxes: int = 9
 
         if old_board:
-            self._store = copy.deepcopy(old_board._store)
+            self._store: list[list[SudokuCell]] = copy.deepcopy(old_board._store)
         else:
             # Create the backing store
-            self._store = []
+            self._store: list[list[SudokuCell]] = []
             for _count in range(0, self.num_rows):
-                self._store.append([None] * self.num_columns)
+                self._store.append([SudokuCell() for _dummy in range(0, self.num_columns)])
 
     @classmethod
     def from_list_of_rows(cls, rows: Sequence[Sequence[int]]) -> 'SudokuBoard':
@@ -199,7 +199,7 @@ class SudokuBoard:
         # A sudoku unit is a subset of the board that must contain one and only one of each number.
         for sudoku_unit in itertools.chain(self.rows, self.columns, self.boxes):
             # Only check filled spaces on this unit of the board
-            sudoku_unit = [num for num in sudoku_unit if num]
+            sudoku_unit = [cell.value for cell in sudoku_unit if cell.value]
             if sudoku_unit and len(frozenset(sudoku_unit)) != len(sudoku_unit):
                 # Invalid if a number has repeated in this unit
                 return False
@@ -210,7 +210,11 @@ class SudokuBoard:
         old_store = copy.deepcopy(self._store)
 
         for element, value in updates.items():
-            self._store[element[0]][element[1]] = value
+            try:
+                self._store[element[0]][element[1]].value = value
+            except ValueError as e:
+                raise InvalidBoardPosition('The update would violate the known'
+                                           f' constraints of cell {element}: {e}') from e
 
         if not self.valid():
             self._store = old_store

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -91,21 +91,18 @@ class TestSudokuCellCreation:
 
         assert cell.value is None
         assert cell.potential_values == frozenset((1, 2, 3, 4, 5, 6, 7, 8, 9))
-        assert not cell.solved
 
     def test_create_cell_given_values(self):
         cell = board.SudokuCell(potential_values=(1, 3, 5, 8))
 
         assert cell.value is None
         assert cell.potential_values == frozenset((1, 3, 5, 8))
-        assert not cell.solved
 
     def test_create_cell_given_one_value(self):
         cell = board.SudokuCell(potential_values=7)
 
         assert cell.value == 7
         assert cell.potential_values == frozenset((7, ))
-        assert cell.solved
 
     @pytest.mark.parametrize('value', INVALID_CELL_VALUES)
     def test_create_cell_invalid(self, value):
@@ -126,16 +123,6 @@ class TestSudokuCellMethods:
         cell = board.SudokuCell(potential_values=potential_values)
         assert repr(cell) == representation
 
-    def test_not_solved(self):
-        cell = board.SudokuCell(potential_values=(7, 8, 9))
-
-        assert not cell.solved
-
-    def test_solved(self):
-        cell = board.SudokuCell(potential_values=(7, ))
-
-        assert cell.solved
-
     def test_get_value_not_yet_solved(self):
         cell = board.SudokuCell(potential_values=(3, 5, 7))
 
@@ -153,7 +140,6 @@ class TestSudokuCellMethods:
         cell.value = 8
 
         assert cell.value == 8
-        assert cell.solved
         assert cell.potential_values == frozenset((8, ))
 
     @pytest.mark.parametrize('value', (v for v in INVALID_CELL_VALUES if isinstance(v, int)))

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -45,7 +45,7 @@ BAD_DATA = {
 
 BAD_DATA_JSON = json.dumps(BAD_DATA)
 
-BLANK_BOARD_DATA: t.List[t.List[t.Optional[int]]] = [[None] * 9 for _c in range(0, 9)]
+BLANK_BOARD_DATA: t.List[t.List[int]] = [[0] * 9 for _c in range(0, 9)]
 
 # The following are all "rotations" of each other
 ONE_EACH_BOARD_ROWS_DATA = copy.deepcopy(BLANK_BOARD_DATA)

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,6 @@
 envlist =
     py310
     py39
-    py38
-    py37
     pre-commit
 isolated_build = true
 


### PR DESCRIPTION
Decided that we're going to store information on potential values that
a cell can take and remain a valid sudoku into the cell itself.  So
we're going to need a cell object, not just an integer.

The currently implemented Sudoku class stores a set of potential values
which the cell could take on internally.  When the list of values is
reduced to a single one, a property will say that the sudoku cell has
been solved and another property will return what the cell's value is.

A single value can be set (useful for initial setup of the board
or for strategies which can determine what the cell's value should be
without eliminating all the other possibilities) and removing
possibilities is done via the `-=` operator.