### PR TITLE
Make sboard fixture generally avaialble and remove SudokuCell.solved tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -104,7 +104,7 @@ repos:
           - pydantic
         args:
           - "--load-plugins=pylint.extensions.mccabe"
-          - "--ignore-patterns=test_.*\\.py"
+          - "--ignore-patterns=test_.*\\.py,conftest.py"
           - "--disable=fixme"
   - repo: https://github.com/jendrikseipp/vulture
     rev: "v2.4"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+import pytest
+
+from suds import board
+
+
+@pytest.fixture
+def sboard(request):
+    """Fixture that returns a SudokuBoard populated with data from the sudoku_data mark."""
+    new_board = board.SudokuBoard()
+    sudoku_data_marker = request.node.get_closest_marker('sudoku_data')
+
+    if not sudoku_data_marker:
+        return new_board
+
+    board_update_format = {}
+    for row_idx, row in enumerate(sudoku_data_marker.args[0]):
+        for col_idx, cell_value in enumerate(row):
+            if cell_value:
+                board_update_format[(row_idx, col_idx)] = cell_value
+
+    new_board.update(board_update_format)
+    return new_board

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -40,24 +40,6 @@ def input_format_to_view_format(values):
     return _list_to_tuple(_values_to_cells(values))
 
 
-@pytest.fixture
-def sboard(request):
-    new_board = board.SudokuBoard()
-    sudoku_data_marker = request.node.get_closest_marker('sudoku_data')
-
-    if not sudoku_data_marker:
-        return new_board
-
-    board_update_format = {}
-    for row_idx, row in enumerate(sudoku_data_marker.args[0]):
-        for col_idx, cell_value in enumerate(row):
-            if cell_value:
-                board_update_format[(row_idx, col_idx)] = cell_value
-
-    new_board.update(board_update_format)
-    return new_board
-
-
 #
 # SudokuCell tests
 #

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -105,16 +105,6 @@ class TestSudokuCellMethods:
         cell = board.SudokuCell(potential_values=potential_values)
         assert repr(cell) == representation
 
-    def test_get_value_not_yet_solved(self):
-        cell = board.SudokuCell(potential_values=(3, 5, 7))
-
-        assert cell.value is None
-
-    def test_get_value_solved(self):
-        cell = board.SudokuCell(potential_values=(3, ))
-
-        assert cell.value == 3
-
     def test_set_value(self):
         cell = board.SudokuCell()
         assert cell.value is None


### PR DESCRIPTION
* sboard fixture is going to become useful in multiple files when strategies are merged.
* When I removed SudokuCell.solved I modified but failed to delete these unittests.